### PR TITLE
Updated how we get scenario name

### DIFF
--- a/elastic_benchmark/main.py
+++ b/elastic_benchmark/main.py
@@ -23,7 +23,7 @@ def parse_output(output):
     json_output = json.loads(output)
     return_data = []
     for o in json_output:
-        scenario_name = o.get("key").get("kw").get("args").get("alternate_name") or o.get("key").get("name")
+        scenario_name = o.get("key").get("name") or o.get("key").get("kw").get("args").get("alternate_name")
         run_id = str(uuid.uuid4())
         for ir in o.get('result'):
             run_at = ir.get('timestamp')

--- a/elastic_benchmark/main.py
+++ b/elastic_benchmark/main.py
@@ -23,7 +23,8 @@ def parse_output(output):
     json_output = json.loads(output)
     return_data = []
     for o in json_output:
-        scenario_name = o.get("key").get("name") or o.get("key").get("kw").get("args").get("alternate_name")
+        scenario_name = o.get("key", {}).get("kw", {}).get("args", {}).get(
+            "alternate_name", None) or o.get("key", {}).get("name", None)
         run_id = str(uuid.uuid4())
         for ir in o.get('result'):
             run_at = ir.get('timestamp')


### PR DESCRIPTION
Was having a problem where a scenario without args was giving an error.  Swapping the order of how we get scenario name fixes that.
